### PR TITLE
Remove deprecated format constants

### DIFF
--- a/client/src/lib/constants/format-constants.ts
+++ b/client/src/lib/constants/format-constants.ts
@@ -1,9 +1,0 @@
-/**
- * @deprecated This file is deprecated. Please import from formatting-constants.ts instead.
- * This file is kept for backward compatibility.
- */
-
-// Re-export from the consolidated file
-import { DATE_FORMATS, NUMBER_FORMATS } from './formatting-constants';
-
-export { DATE_FORMATS, NUMBER_FORMATS };


### PR DESCRIPTION
## Summary
- delete deprecated `format-constants.ts` since all imports use `formatting-constants.ts`

## Testing
- `./scripts/lint.sh` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68487379cf448322a279c9a4a07355ec